### PR TITLE
Update nuke_cache_if_too_big.sh

### DIFF
--- a/nuke_cache_if_too_big.sh
+++ b/nuke_cache_if_too_big.sh
@@ -7,6 +7,7 @@ function nuke_if_too_big() {
     rm -rf ${path}
   fi
 }
+nuke_if_too_big ~/.cache/pants 1
 
 nuke_if_too_big ~/.cache/pants/lmdb_store 2048
 nuke_if_too_big ~/.cache/pants/setup 768


### PR DESCRIPTION
try to address issues with pants bootstrap failing when setup cache is cleared.